### PR TITLE
[Feat] Mqtt 수신 데이터 파싱

### DIFF
--- a/src/main/java/com/example/smartair/config/MqttConfig.java
+++ b/src/main/java/com/example/smartair/config/MqttConfig.java
@@ -1,5 +1,7 @@
 package com.example.smartair.config;
 
+import com.example.smartair.dto.airQualityDataDto.AirQualityPayloadDto;
+import com.example.smartair.dto.mqttMessageDto.MqttMessageRequestDto;
 import com.example.smartair.service.mqttService.MqttReceiveService;
 import org.springframework.integration.mqtt.outbound.MqttPahoMessageHandler;
 import org.springframework.messaging.MessageHandler;
@@ -56,8 +58,8 @@ public class MqttConfig {
     public MessageHandler handler(MqttReceiveService mqttReceiveService) {
         return message -> {
             String topic = (String) message.getHeaders().get("mqtt_receivedTopic");
-            String payload = (String) message.getPayload();
-            mqttReceiveService.handleReceiveMessage(topic, payload);
+            AirQualityPayloadDto payloadDto = (AirQualityPayloadDto) message.getPayload();
+            mqttReceiveService.handleReceiveMessage(topic, payloadDto);
         };
     }
 

--- a/src/main/java/com/example/smartair/config/SwaggerConfig.java
+++ b/src/main/java/com/example/smartair/config/SwaggerConfig.java
@@ -23,8 +23,8 @@ public class SwaggerConfig {
         SecurityRequirement securityRequirement = new SecurityRequirement().addList("BearerAuth");
 
         return new OpenAPI()
-                .info(new Info().title("Todolist API")
-                        .description("Todolist Application API Documentation")
+                .info(new Info().title("SmartAir API")
+                        .description("SmartAir Application API Documentation")
                         .version("v1.0"))
                 .addSecurityItem(securityRequirement)  // Security Requirement 추가
                 .schemaRequirement("BearerAuth", securityScheme);  // Security Scheme 추가

--- a/src/main/java/com/example/smartair/controller/mqttController/MqttReceiveController.java
+++ b/src/main/java/com/example/smartair/controller/mqttController/MqttReceiveController.java
@@ -13,7 +13,7 @@ import java.util.List;
 @RestController
 @Slf4j
 @RequestMapping("/mqtt/receive")
-public class MqttReceiveController {
+public class MqttReceiveController implements MqttReceiveControllerDocs{
 
     private final MqttReceiveService mqttReceiveService;
 

--- a/src/main/java/com/example/smartair/controller/mqttController/MqttReceiveControllerDocs.java
+++ b/src/main/java/com/example/smartair/controller/mqttController/MqttReceiveControllerDocs.java
@@ -1,0 +1,28 @@
+package com.example.smartair.controller.mqttController;
+
+import com.example.smartair.dto.mqttMessageDto.MqttMessageRequestDto;
+import io.swagger.v3.oas.annotations.Operation;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+public interface MqttReceiveControllerDocs {
+    @Operation(
+            summary = "MQTT 메시지 수신 및 처리", // 요약을 좀 더 명확하게
+            description = """
+                    **MQTT 메시지 수신 및 처리**
+
+                    MQTT 메시지를 JSON 형식으로 전달받아 처리하고, 관련 데이터를 데이터베이스에 저장합니다.
+                    요청 본문은 `topic`과 `payload` 객체를 포함해야 합니다.
+
+                    **입력 파라미터 (`RequestBody`)**
+                    - `topic` (String): 메시지가 발행된 MQTT 토픽 문자열입니다. 일반적으로 `/`로 구분된 계층 구조를 가지며, 메시지 출처(디바이스 ID, 방 ID)를 식별하는 데 사용됩니다. (예: `smartair/1/1/airquality`)
+                    - `payload` (AirQualityPayloadDto): 측정된 공기질 센서 데이터 객체입니다. 온도, 습도, 미세먼지 농도, 입자 개수 등 다양한 측정값을 포함합니다. 상세 구조는 아래 **Schema**를 참조하세요.
+
+                    **반환값**
+                    - 성공 시 (HTTP 200 OK): 메시지 처리 완료를 나타내는 확인 문자열입니다. (예: "테스트 메시지 처리 완료 ...") 
+                    - 실패 시: 오류 코드 및 메시지를 포함하는 JSON 응답입니다.
+                    """
+    )
+    ResponseEntity<String> receiveMqttMessage(@RequestBody MqttMessageRequestDto requestDto);
+}

--- a/src/main/java/com/example/smartair/dto/mqttMessageDto/MqttMessageRequestDto.java
+++ b/src/main/java/com/example/smartair/dto/mqttMessageDto/MqttMessageRequestDto.java
@@ -1,11 +1,14 @@
 package com.example.smartair.dto.mqttMessageDto;
 
-import lombok.Getter;
+import com.example.smartair.dto.airQualityDataDto.AirQualityPayloadDto;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Getter
+@Data
 @NoArgsConstructor
+@AllArgsConstructor
 public class MqttMessageRequestDto {
     private String topic;
-    private String payload;
+    private AirQualityPayloadDto payload;
 }

--- a/src/main/java/com/example/smartair/entity/airData/airQualityData/DeviceAirQualityData.java
+++ b/src/main/java/com/example/smartair/entity/airData/airQualityData/DeviceAirQualityData.java
@@ -1,6 +1,7 @@
 package com.example.smartair.entity.airData.airQualityData;
 
 import com.example.smartair.entity.airData.fineParticlesData.FineParticlesData;
+import com.example.smartair.entity.airData.fineParticlesData.FineParticlesDataPt2;
 import com.example.smartair.entity.airData.predictedAirQualityData.PredictedAirQualityData;
 import com.example.smartair.entity.device.Device;
 import com.example.smartair.entity.room.Room;
@@ -13,14 +14,13 @@ import lombok.*;
 @AllArgsConstructor
 @Getter
 @Builder
-@Setter
+@Table(name = "device_air_quality_data")
 public class DeviceAirQualityData extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String topic;
-    private String payload;
 
     private double temperature; //온도
     private double humidity; //습도
@@ -31,15 +31,19 @@ public class DeviceAirQualityData extends BaseEntity {
     private int rawh2;
     private int rawethanol;
 
-    @ManyToOne //공기질 데이터와 기기 : 다대일
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "device_id")
     private Device device;
 
-    @OneToOne
-    @JoinColumn(name = "fineParticlesData_id") //공기질 데이터와 미세먼지 데이터 : 일대일
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "fine_particles_data_id") // 외래 키 컬럼명 지정
     private FineParticlesData fineParticlesData;
 
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "fine_particles_data_pt2_id") // 외래 키 컬럼명 지정
+    private FineParticlesDataPt2 fineParticlesDataPt2;
+
     @OneToOne
-    @JoinColumn(name = "predictedAirQuality_id")
+    @JoinColumn(name = "predictedAirQuality_data_id")
     private PredictedAirQualityData predictedAirQualityData;
 }

--- a/src/main/java/com/example/smartair/entity/airData/fineParticlesData/FineParticlesDataPt2.java
+++ b/src/main/java/com/example/smartair/entity/airData/fineParticlesData/FineParticlesDataPt2.java
@@ -1,0 +1,33 @@
+package com.example.smartair.entity.airData.fineParticlesData;
+
+import com.example.smartair.entity.device.Device;
+import com.example.smartair.util.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FineParticlesDataPt2 extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private double pm10_standard;
+    private double pm25_standard;
+    private double pm100_standard;
+
+    private int particle_03;
+    private int particle_05;
+    private int particle_10;
+    private int particle_25;
+    private int particle_50;
+    private int particle_100;
+
+    @ManyToOne
+    @JoinColumn(name = "device_id")
+    private Device device;
+}

--- a/src/main/java/com/example/smartair/exception/ErrorCode.java
+++ b/src/main/java/com/example/smartair/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
 
     // === mqtt 관련 오류 코드 ===
     MQTT_PROCESSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "MQTT 데이터 처리 중 오류 발생"),
+    MQTT_INVALID_TOPIC_ERROR(HttpStatus.BAD_REQUEST, "MQTT 토픽 형식이 유효하지 않습니다."),
 
     // === AirQualityScoreService 관련 오류 코드 ===
 

--- a/src/main/java/com/example/smartair/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/smartair/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.example.smartair.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -19,9 +20,11 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(RuntimeException.class)
-    public String handleRuntimeException() {
-        log.info("RuntimeException 처리 시작");
-        return "Runtime Exception 핸들링";
+    public ResponseEntity<?> handleRuntimeException(RuntimeException e) {
+        log.info("RuntimeException 발생: {}", e.getMessage(), e);
+        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(Collections.singletonMap("error", errorCode.getMessage()));
     }
 
 }

--- a/src/main/java/com/example/smartair/repository/airQualityDataRepository/FineParticlesDataPt2Repository.java
+++ b/src/main/java/com/example/smartair/repository/airQualityDataRepository/FineParticlesDataPt2Repository.java
@@ -1,0 +1,9 @@
+package com.example.smartair.repository.airQualityDataRepository;
+
+import com.example.smartair.entity.airData.fineParticlesData.FineParticlesDataPt2;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FineParticlesDataPt2Repository extends JpaRepository<FineParticlesDataPt2, Long> {
+}

--- a/src/main/java/com/example/smartair/repository/airQualityDataRepository/FineParticlesDataRepository.java
+++ b/src/main/java/com/example/smartair/repository/airQualityDataRepository/FineParticlesDataRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface FineParticlesDataRepository extends JpaRepository<FineParticlesData, Integer> {
+public interface FineParticlesDataRepository extends JpaRepository<FineParticlesData, Long> {
 }

--- a/src/main/java/com/example/smartair/repository/airQualityDataRepository/RoomAirQualityDataRepository.java
+++ b/src/main/java/com/example/smartair/repository/airQualityDataRepository/RoomAirQualityDataRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface RoomAirQualityDataRepository extends JpaRepository<RoomAirQualityData, Integer> {
+public interface RoomAirQualityDataRepository extends JpaRepository<RoomAirQualityData, Long> {
 }

--- a/src/main/java/com/example/smartair/service/MqttService/MqttReceiveService.java
+++ b/src/main/java/com/example/smartair/service/MqttService/MqttReceiveService.java
@@ -2,26 +2,32 @@ package com.example.smartair.service.mqttService;
 
 import com.example.smartair.dto.airQualityDataDto.AirQualityPayloadDto;
 import com.example.smartair.entity.airData.airQualityData.DeviceAirQualityData;
+import com.example.smartair.exception.CustomException;
+import com.example.smartair.exception.ErrorCode;
 import com.example.smartair.service.airQualityService.AirQualityDataService;
 import org.springframework.stereotype.Service;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.LinkedList;
 import java.util.List;
 
 @Service
+@RequiredArgsConstructor
+@Slf4j
 public class MqttReceiveService {
 
     private final LinkedList<DeviceAirQualityData> recentMessage = new LinkedList<>();
     private final AirQualityDataService airQualityDataService;
 
-    public MqttReceiveService(AirQualityDataService airQualityDataService) {
-        this.airQualityDataService = airQualityDataService;
-    }
-
-
-    public AirQualityPayloadDto handleReceiveMessage(String topic, String payload){
-        return airQualityDataService.processAirQualityData(topic, payload);
-
+    public AirQualityPayloadDto handleReceiveMessage(String topic, AirQualityPayloadDto dto) {
+        try {
+            log.info("Received message on topic '{}'", topic);
+            return airQualityDataService.processAirQualityData(topic, dto);
+        } catch (Exception e) {
+            log.error("Error handling MQTT message: Topic={}, Payload={}", topic, dto, e);
+            throw new CustomException(ErrorCode.MQTT_PROCESSING_ERROR);
+        }
     }
 
 //    public Long extractDeviceIdFromTopic(String topic) {


### PR DESCRIPTION
## #️⃣ Issue Number
#44 

## 📝 요약(Summary)
MQTT를 통해 실시간으로 수신되는 공기질 데이터(JSON 형식)를 성공적으로 파싱하고, 이를 `AirQualityPayloadDto` 객체로 변환한 뒤, 최종적으로 데이터베이스에 저장하는 기능을 구현했습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [x] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
MqttReceiveControllerDocs를 작성하였습니다. Swagger에서 세부 설명을 확인 가능합니다.
AirQualityScoreCalculatorTest에서 에러가 발생하는데, 다음 기능을 구현하면서 수정하겠습니다.
