### PR TITLE
[Feat] 공기질 데이터 계산 및 스케줄링 구현

### DIFF
--- a/src/main/java/com/example/smartair/SmartAirApplication.java
+++ b/src/main/java/com/example/smartair/SmartAirApplication.java
@@ -4,8 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 public class SmartAirApplication {
 

--- a/src/main/java/com/example/smartair/controller/airQualityScoreController/AirQualityScoreController.java
+++ b/src/main/java/com/example/smartair/controller/airQualityScoreController/AirQualityScoreController.java
@@ -4,6 +4,7 @@ import com.example.smartair.dto.airQualityScoreDto.DeviceAirQualityScoreDto;
 import com.example.smartair.dto.airQualityScoreDto.PlaceAirQualityScoreDto;
 import com.example.smartair.dto.airQualityScoreDto.RoomAirQualityScoreDto;
 import com.example.smartair.service.airQualityService.AirQualityQueryService;
+import com.example.smartair.service.airQualityService.AirQualityScoreService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -14,7 +15,7 @@ import java.time.LocalDateTime;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/airquality/scores")
+@RequestMapping("/airquality/scores")
 public class AirQualityScoreController {
 
     private final AirQualityQueryService airQualityQueryService;
@@ -116,4 +117,5 @@ public class AirQualityScoreController {
         PlaceAirQualityScoreDto score = airQualityQueryService.getLatestPlaceAirQualityScore(placeId);
         return ResponseEntity.ok(score);
     }
+
 }

--- a/src/main/java/com/example/smartair/dto/airQualityScoreDto/AverageScoreDto.java
+++ b/src/main/java/com/example/smartair/dto/airQualityScoreDto/AverageScoreDto.java
@@ -1,0 +1,18 @@
+package com.example.smartair.dto.airQualityScoreDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Builder; // 빌더 추가 (선택적이지만 편리함)
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AverageScoreDto {
+    private double overallScore;
+    private double pm10Score;
+    private double pm25Score;
+    private double eco2Score;
+    private double tvocScore;
+}

--- a/src/main/java/com/example/smartair/exception/ErrorCode.java
+++ b/src/main/java/com/example/smartair/exception/ErrorCode.java
@@ -13,10 +13,6 @@ public enum ErrorCode {
     DEVICE_NOT_FOUND(HttpStatus.NOT_FOUND, "기기를 찾을 수 없습니다."),
     ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "등록되지 않은 방입니다."),
     PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "등록되지 않은 공간입니다."),
-    DEVICE_AIR_DATA_NOT_FOUND(HttpStatus.NOT_FOUND, "기기의 공기질 데이터를 찾을 수 없습니다."),
-    ROOM_SCORE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 방의 공기질 점수 정보를 찾을 수 없습니다."),
-    PLACE_SCORE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 공간의 공기질 점수 정보를 찾을 수 없습니다."),
-    DEVICE_SCORE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 기기의 공기질 점수 정보를 찾을 수 없습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
     ROOM_DEVICE_MAPPING_NOT_FOUND(HttpStatus.NOT_FOUND, "방과 디바이스의 매핑 정보를 찾을 수 없습니다."),
     
@@ -31,8 +27,13 @@ public enum ErrorCode {
     MQTT_INVALID_TOPIC_ERROR(HttpStatus.BAD_REQUEST, "MQTT 토픽 형식이 유효하지 않습니다."),
 
     // === AirQualityScoreService 관련 오류 코드 ===
-
     ROOM_AIR_QUALITY_SCORE_IS_EMPTY(HttpStatus.NO_CONTENT, "Room 점수 데이터가 비어있습니다."),
+    ROOM_SCORE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 방의 공기질 점수 정보를 찾을 수 없습니다."),
+    PLACE_SCORE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 공간의 공기질 점수 정보를 찾을 수 없습니다."),
+    DEVICE_SCORE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 기기의 공기질 점수 정보를 찾을 수 없습니다."),
+
+    // === AirQualityData 관련 오류 코드 ===
+    DEVICE_AIR_DATA_NOT_FOUND(HttpStatus.NOT_FOUND, "기기의 공기질 데이터를 찾을 수 없습니다."),
 
     // === Satisfaction 관련 오류 코드 ===
 

--- a/src/main/java/com/example/smartair/repository/airQualityDataRepository/AirQualityDataRepository.java
+++ b/src/main/java/com/example/smartair/repository/airQualityDataRepository/AirQualityDataRepository.java
@@ -4,7 +4,11 @@ import com.example.smartair.entity.airData.airQualityData.DeviceAirQualityData;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface AirQualityDataRepository extends JpaRepository<DeviceAirQualityData, Long> {
+
+    List<DeviceAirQualityData> findTop7ByDeviceIdOrderByCreatedAtDesc(Long deviceId);
 
 }

--- a/src/main/java/com/example/smartair/repository/airQualityScoreRepository/DeviceAirQualityScoreRepository.java
+++ b/src/main/java/com/example/smartair/repository/airQualityScoreRepository/DeviceAirQualityScoreRepository.java
@@ -27,4 +27,6 @@ public interface DeviceAirQualityScoreRepository extends JpaRepository<DeviceAir
             Pageable pageable
     );
 
+    Optional<DeviceAirQualityScore> findTopByDeviceAirQualityData_DeviceOrderByCreatedAtDesc(Device device);
+
 } 

--- a/src/main/java/com/example/smartair/repository/deviceRepository/DeviceRepository.java
+++ b/src/main/java/com/example/smartair/repository/deviceRepository/DeviceRepository.java
@@ -1,12 +1,18 @@
 package com.example.smartair.repository.deviceRepository;
 
+import com.example.smartair.entity.airData.airQualityData.DeviceAirQualityData;
 import com.example.smartair.entity.device.Device;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface DeviceRepository extends JpaRepository<Device, Long> {
     Optional<Device> findById(Long id);
+
+    @Query("SELECT das.id FROM Device das WHERE das.runningStatus = true")
+    List<Long> findAllRunningDeviceIds();
 }

--- a/src/main/java/com/example/smartair/repository/roomDeviceRepository/RoomDeviceRepository.java
+++ b/src/main/java/com/example/smartair/repository/roomDeviceRepository/RoomDeviceRepository.java
@@ -1,13 +1,17 @@
 package com.example.smartair.repository.roomDeviceRepository;
 
 import com.example.smartair.entity.device.Device;
+import com.example.smartair.entity.room.Room;
 import com.example.smartair.entity.roomDevice.RoomDevice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface RoomDeviceRepository extends JpaRepository<RoomDevice, Long> {
     Optional<RoomDevice> findByDevice(Device device);
+
+    List<Device> findAllDeviceByRoom(Room room);
 }

--- a/src/main/java/com/example/smartair/service/airQualityService/AirQualityScoreService.java
+++ b/src/main/java/com/example/smartair/service/airQualityService/AirQualityScoreService.java
@@ -1,5 +1,8 @@
 package com.example.smartair.service.airQualityService;
 
+import com.example.smartair.dto.airQualityScoreDto.AverageScoreDto;
+import com.example.smartair.dto.airQualityScoreDto.DeviceAirQualityScoreDto;
+import com.example.smartair.dto.airQualityScoreDto.RoomAirQualityScoreDto;
 import com.example.smartair.entity.airData.airQualityData.DeviceAirQualityData;
 import com.example.smartair.entity.airScore.airQualityScore.DeviceAirQualityScore;
 import com.example.smartair.entity.airScore.airQualityScore.RoomAirQualityScore;
@@ -13,14 +16,18 @@ import com.example.smartair.exception.ErrorCode;
 import com.example.smartair.repository.airQualityScoreRepository.DeviceAirQualityScoreRepository;
 import com.example.smartair.repository.airQualityScoreRepository.RoomAirQualityScoreRepository;
 import com.example.smartair.repository.airQualityScoreRepository.PlaceAirQualityScoreRepository;
+import com.example.smartair.repository.deviceRepository.DeviceRepository;
 import com.example.smartair.repository.roomDeviceRepository.RoomDeviceRepository;
+import com.example.smartair.repository.roomRepository.RoomRepository;
 import com.example.smartair.service.airQualityService.calculator.AirQualityCalculator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -32,13 +39,14 @@ public class AirQualityScoreService {
     private final RoomAirQualityScoreRepository roomAirQualityScoreRepository;
     private final PlaceAirQualityScoreRepository placeAirQualityScoreRepository;
     private final RoomDeviceRepository roomDeviceRepository;
+    private final RoomRepository roomRepository;
 
     /**
-     * 주어진 AirQualityData를 기반으로 점수 기록을 생성합니다.
+     * 주어진 AirQualityData를 기반으로 공기질 점수를 계산합니다.
      * @param airQualityData
      */
     @Transactional
-    public void calculateAndSaveScores(DeviceAirQualityData airQualityData) {
+    public void calculateAndSaveDeviceScore(DeviceAirQualityData airQualityData) {
         if (airQualityData == null) {
            throw new CustomException(ErrorCode.INVALID_INPUT_DATA);
         }
@@ -50,70 +58,202 @@ public class AirQualityScoreService {
                 .map(RoomDevice::getRoom)
                 .orElseThrow(() -> new CustomException(ErrorCode.ROOM_DEVICE_MAPPING_NOT_FOUND));
 
-        // 1. 개별 DeviceAirQualityScore 계산 및 저장
+        // 개별 DeviceAirQualityScore 계산 및 저장
         DeviceAirQualityScore calculatedDeviceScore = airQualityCalculator.calculateScore(airQualityData);
         calculatedDeviceScore.setDeviceAirQualityData(airQualityData);
         deviceAirQualityScoreRepository.save(calculatedDeviceScore);
         log.info("DeviceAirQualityScore 저장 완료: ID {}", calculatedDeviceScore.getId());
 
-        // 2. RoomAirQualityScore 생성
-        createRoomAirQualityScore(room, calculatedDeviceScore);
+        // 방 평균 점수 업데이트 트리거
+        try {
+            updateRoomAverageScore(room); // room 객체 전달
+        } catch (Exception e) {
+            log.error("Room ID {}의 평균 점수 업데이트 중 오류 발생", room.getId(), e);
+        }
+    }
 
-        // 3. PlaceAirQualityScore 생성
+    private void updateRoomAverageScore(Room room) {
+        log.info("Updating average score for Room ID: {}", room.getId());
+        List<DeviceAirQualityScore> airQualityScoreList = new ArrayList<>();
+        List<Device> deviceList = roomDeviceRepository.findAllDeviceByRoom(room);
+
+        if (deviceList.isEmpty()) {
+            log.warn("Room ID: {} 에 속한 Device가 없습니다. 평균 점수 계산을 건너뛰었습니다.", room.getId());
+            return; // 처리할 디바이스 없으면 종료
+        }
+
+        for (Device device : deviceList) {
+            try {
+                //디바이스의 최신 한 건의 공기질 점수 데이터 조회
+                deviceAirQualityScoreRepository.findTopByDeviceAirQualityData_DeviceOrderByCreatedAtDesc(device)
+                        .ifPresent(airQualityScoreList::add);
+                // .orElseThrow() 대신 ifPresent 사용으로 점수 없는 디바이스는 그냥 넘어감
+            } catch (Exception e) { // 데이터 조회 중 예외 처리 (예: DB 연결 문제)
+                log.error("Device ID {}의 최신 공기질 점수 조회 중 오류 발생", device.getId(), e);
+            }
+        }
+
+        // 방에 존재하는 모든 디바이스 공기질 데이터의 평균 데이터 계산
+        AverageScoreDto averageDeviceScoreDto = calculateAverageDeviceScore(airQualityScoreList);
+
+        // 기존 RoomAirQualityScore 조회
+        Optional<RoomAirQualityScore> existingRoomScoreOptional = roomAirQualityScoreRepository.findFirstByRoomOrderByCreatedAtDesc(room);
+        RoomAirQualityScore roomScoreToSave; // 저장할 객체 선언
+
+        if (existingRoomScoreOptional.isPresent()) {
+            // 기존 기록 업데이트
+            roomScoreToSave = existingRoomScoreOptional.get();
+            log.info("Room ID {}의 기존 평균 점수 레코드(ID: {})를 업데이트합니다.", room.getId(), roomScoreToSave.getId());
+        } else {
+            // 신규 기록 생성
+            roomScoreToSave = new RoomAirQualityScore();
+            roomScoreToSave.setRoom(room);
+            log.info("Room ID {}의 평균 점수 레코드를 신규 생성합니다.", room.getId());
+        }
+
+        // 평균 점수 DTO 값으로 업데이트/설정
+        roomScoreToSave.setOverallScore(averageDeviceScoreDto.getOverallScore());
+        roomScoreToSave.setPm10Score(averageDeviceScoreDto.getPm10Score());
+        roomScoreToSave.setPm25Score(averageDeviceScoreDto.getPm25Score());
+        roomScoreToSave.setEco2Score(averageDeviceScoreDto.getEco2Score());
+        roomScoreToSave.setTvocScore(averageDeviceScoreDto.getTvocScore());
+        roomAirQualityScoreRepository.save(roomScoreToSave);
+        log.info("Room ID {}의 평균 점수 저장 완료 (Score ID: {})", room.getId(), roomScoreToSave.getId());
+
+        // 공간 평균 점수 업데이트 트리거
         Place place = room.getPlace();
         if (place != null) {
-            createPlaceAirQualityScore(place);
+            try {
+                updatePlaceAverageScore(place); // 공간 점수 업데이트 메서드 호출
+            } catch (Exception e) {
+                log.error("Place ID {}의 평균 점수 업데이트 중 오류 발생 (Triggered from Room ID {})", place.getId(), room.getId(), e);
+            }
+        } else {
+            log.warn("Room ID {}에 연결된 Place 정보가 없어 Place 점수 업데이트를 건너뛰었습니다.", room.getId());
+        }
+    }
+
+    // 공간 평균 점수 업데이트 메서드
+    private void updatePlaceAverageScore(Place place) {
+        log.info("Placeholder: updatePlaceAverageScore called for Place ID: {}", place.getId());
+
+        List<RoomAirQualityScore> roomAirQualityScoreList = new ArrayList<>();
+
+        // 1. place에 속한 room 목록 조회
+         List<Room> roomList = roomRepository.findAllByPlace(place);
+         if (roomList.isEmpty()) {
+             log.warn("Place ID: {}에 속한 Room이 없습니다.", place.getId());
+             return;
+         }
+
+        // 2. 각 room의 최신 RoomAirQualityScore 조회
+        for (Room room : roomList) {
+            roomAirQualityScoreRepository.findFirstByRoomOrderByCreatedAtDesc(room)
+                    .ifPresent(roomAirQualityScoreList::add);
+        }
+
+        // 3. 점수들 평균 계산
+        AverageScoreDto averageRoomScoreDto = calculateAverageRoomScore(roomAirQualityScoreList);
+
+        // 4. 기존 PlaceAirQualityScore 조회 및 업데이트/생성
+        Optional<PlaceAirQualityScore> existingPlaceScoreOptional = placeAirQualityScoreRepository.findFirstByPlaceOrderByCreatedAtDesc(place);
+        PlaceAirQualityScore placeScoreToSave;
+
+        if (existingPlaceScoreOptional.isPresent()) {
+            placeScoreToSave = existingPlaceScoreOptional.get();
+            log.info("Place ID {}의 기존 평균 점수 레코드(ID: {})를 업데이트합니다.", place.getId(), placeScoreToSave.getId());
         }
         else{
-            log.warn("Room ID {}에 Place 정보가 없어 PlaceAirQualityScore 생성을 건너뛰었습니다.", room.getId());
-        }
-    }
-
-    /**
-     * 특정 방의 새로운 공기질 점수 기록을 생성합니다.
-     * @param room 대상 방
-     * @param calculatedDeviceScore 계산된 개별 점수 객체 (원본 값 제공 용도)
-     */
-    private void createRoomAirQualityScore(Room room, DeviceAirQualityScore calculatedDeviceScore) {
-        RoomAirQualityScore newRoomScore = new RoomAirQualityScore();
-        newRoomScore.setRoom(room);
-        newRoomScore.setOverallScore(calculatedDeviceScore.getOverallScore());
-        newRoomScore.setPm10Score(calculatedDeviceScore.getPm10Score());
-        newRoomScore.setPm25Score(calculatedDeviceScore.getPm25Score());
-        newRoomScore.setEco2Score(calculatedDeviceScore.getEco2Score());
-        newRoomScore.setTvocScore(calculatedDeviceScore.getTvocScore());
-
-        roomAirQualityScoreRepository.save(newRoomScore);
-        log.info("RoomAirQualityScore 생성 완료: Room ID {}, Score ID {}", room.getId(), newRoomScore.getId());
-    }
-
-    /**
-     * 특정 공간의 새로운 전체 공기질 점수 기록을 생성합니다. (해당 공간 모든 방의 점수 기록 평균)
-     * @param place 대상 공간
-     */
-    private void createPlaceAirQualityScore(Place place) {
-        List<RoomAirQualityScore> roomScores = roomAirQualityScoreRepository.findByRoom_Place(place);
-
-        if (roomScores.isEmpty()) {
-            log.warn("Place ID {}에 대한 Room 점수 데이터가 없어 PlaceAirQualityScore를 생성하지 않습니다.", place.getId());
-            return;
+            placeScoreToSave = new PlaceAirQualityScore();
+            placeScoreToSave.setPlace(place);
+            log.info("Place ID {}의 평균 점수 레코드를 신규 생성합니다.", place.getId());
         }
 
-        double avgOverall = roomScores.stream().mapToDouble(RoomAirQualityScore::getOverallScore).average().orElse(0.0);
-        double avgPm10 = roomScores.stream().mapToDouble(RoomAirQualityScore::getPm10Score).average().orElse(0.0);
-        double avgPm25 = roomScores.stream().mapToDouble(RoomAirQualityScore::getPm25Score).average().orElse(0.0);
-        double avgEco2 = roomScores.stream().mapToDouble(RoomAirQualityScore::getEco2Score).average().orElse(0.0);
-        double avgTvoc = roomScores.stream().mapToDouble(RoomAirQualityScore::getTvocScore).average().orElse(0.0);
+        // 5. 저장
+        placeScoreToSave.setOverallScore(averageRoomScoreDto.getOverallScore());
+        placeScoreToSave.setPm10Score(averageRoomScoreDto.getPm10Score());
+        placeScoreToSave.setPm25Score(averageRoomScoreDto.getPm25Score());
+        placeScoreToSave.setEco2Score(averageRoomScoreDto.getEco2Score());
+        placeScoreToSave.setTvocScore(averageRoomScoreDto.getTvocScore());
+        placeAirQualityScoreRepository.save(placeScoreToSave);
+        log.info("Place ID {}의 평균 점수 저장 완료 (Score ID: {})", place.getId(), placeScoreToSave.getId());
+    }
 
-        PlaceAirQualityScore newTotalScore = new PlaceAirQualityScore();
-        newTotalScore.setPlace(place);
-        newTotalScore.setOverallScore(avgOverall);
-        newTotalScore.setPm10Score(avgPm10);
-        newTotalScore.setPm25Score(avgPm25);
-        newTotalScore.setEco2Score(avgEco2);
-        newTotalScore.setTvocScore(avgTvoc);
+    private AverageScoreDto calculateAverageRoomScore(List<RoomAirQualityScore> airQualityScoreList) {
+        log.info("===calculateAverageRoomScore 실행 시작 ({}개 데이터)===", airQualityScoreList.size());
 
-        placeAirQualityScoreRepository.save(newTotalScore);
-        log.info("PlaceAirQualityScore 생성 완료: Place ID {}, Score ID {}", place.getId(), newTotalScore.getId());
+        // 빈 리스트 체크 추가
+        if (airQualityScoreList.isEmpty()) {
+            log.warn("평균 점수 계산 대상 리스트가 비어있습니다. 0점을 반환합니다.");
+            return AverageScoreDto.builder()
+                    .overallScore(0.0).pm10Score(0.0).pm25Score(0.0)
+                    .eco2Score(0.0).tvocScore(0.0).build();
+        }
+
+        double sumOverallScore = 0; // 변수 이름 명확화 (sum)
+        double sumPm10Score = 0;
+        double sumPm25Score = 0;
+        double sumEco2Score = 0;
+        double sumTvocScore = 0;
+
+        for (RoomAirQualityScore roomAirQualityScore : airQualityScoreList) {
+            sumOverallScore += roomAirQualityScore.getOverallScore();
+            sumPm10Score += roomAirQualityScore.getPm10Score();
+            sumPm25Score += roomAirQualityScore.getPm25Score();
+            sumEco2Score += roomAirQualityScore.getEco2Score();
+            sumTvocScore += roomAirQualityScore.getTvocScore();
+        }
+
+        int count = airQualityScoreList.size(); // 개수 미리 계산
+
+        AverageScoreDto averageScoreDto = AverageScoreDto.builder()
+                .overallScore(sumOverallScore / count) // 평균 계산
+                .pm10Score(sumPm10Score / count)
+                .pm25Score(sumPm25Score / count)
+                .eco2Score(sumEco2Score / count)
+                .tvocScore(sumTvocScore / count)
+                .build(); // DTO에 deviceId, timestamp 등은 포함되지 않음
+
+        log.info("===calculateAverageRoomScore 실행 완료===");
+        return averageScoreDto;
+    }
+
+    private AverageScoreDto calculateAverageDeviceScore(List<DeviceAirQualityScore> airQualityScoreList) {
+        log.info("===calculateAverageDeviceScore 실행 시작 ({}개 데이터)===", airQualityScoreList.size());
+
+        // 빈 리스트 체크 추가
+        if (airQualityScoreList.isEmpty()) {
+            log.warn("평균 점수 계산 대상 리스트가 비어있습니다. 0점을 반환합니다.");
+            return AverageScoreDto.builder()
+                    .overallScore(0.0).pm10Score(0.0).pm25Score(0.0)
+                    .eco2Score(0.0).tvocScore(0.0).build();
+        }
+
+        double sumOverallScore = 0; // 변수 이름 명확화 (sum)
+        double sumPm10Score = 0;
+        double sumPm25Score = 0;
+        double sumEco2Score = 0;
+        double sumTvocScore = 0;
+
+        for (DeviceAirQualityScore deviceAirQualityScore : airQualityScoreList) {
+            sumOverallScore += deviceAirQualityScore.getOverallScore();
+            sumPm10Score += deviceAirQualityScore.getPm10Score();
+            sumPm25Score += deviceAirQualityScore.getPm25Score();
+            sumEco2Score += deviceAirQualityScore.getEco2Score();
+            sumTvocScore += deviceAirQualityScore.getTvocScore();
+        }
+
+        int count = airQualityScoreList.size(); // 개수 미리 계산
+
+        AverageScoreDto averageScoreDto = AverageScoreDto.builder()
+                .overallScore(sumOverallScore / count) // 평균 계산
+                .pm10Score(sumPm10Score / count)
+                .pm25Score(sumPm25Score / count)
+                .eco2Score(sumEco2Score / count)
+                .tvocScore(sumTvocScore / count)
+                .build(); // DTO에 deviceId, timestamp 등은 포함되지 않음
+
+        log.info("===calculateAverageDeviceScore 실행 완료===");
+        return averageScoreDto;
     }
 }

--- a/src/main/java/com/example/smartair/service/airQualityService/scheduler/AirQualityScoreCalculationScheduler.java
+++ b/src/main/java/com/example/smartair/service/airQualityService/scheduler/AirQualityScoreCalculationScheduler.java
@@ -1,0 +1,79 @@
+package com.example.smartair.service.airQualityService.scheduler;
+
+import com.example.smartair.entity.airData.airQualityData.DeviceAirQualityData;
+import com.example.smartair.exception.CustomException;
+import com.example.smartair.exception.ErrorCode;
+import com.example.smartair.repository.airQualityDataRepository.AirQualityDataRepository;
+import com.example.smartair.repository.deviceRepository.DeviceRepository;
+import com.example.smartair.service.airQualityService.AirQualityScoreService;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Setter
+@RequiredArgsConstructor
+@Slf4j
+public class AirQualityScoreCalculationScheduler {
+
+    private final DeviceRepository deviceRepository;
+    private final AirQualityDataRepository airQualityDataRepository;
+    private final AirQualityScoreService airQualityScoreService;
+
+    @Scheduled(fixedRate = 1800000) //30분 간격
+    public void calculateAirQualityScoresPeriodically() {
+        LocalDateTime startTime = LocalDateTime.now();
+        log.info("===Started Calculating air quality score periodically at {}===", startTime);
+
+        int processedCount = 0;
+        int failedCount = 0;
+
+        //활성 디바이스 ID 목록 조회
+        List<Long> runningDeviceIDs = deviceRepository.findAllRunningDeviceIds();
+        log.info("Found running devices: {}", runningDeviceIDs);
+
+        for (Long runningDeviceID : runningDeviceIDs) {
+            try{
+                log.info("Processing air quality score for device ID: {}", runningDeviceID);
+                calculateScoresForDevice(runningDeviceID);
+                processedCount++;
+            }
+            catch (Exception e){
+                log.error("Error processing air quality score for device ID: {}", runningDeviceID, e);
+                failedCount++;
+            }
+        }
+
+        LocalDateTime endTime = LocalDateTime.now();
+        Duration duration = Duration.between(startTime, endTime);
+        log.info("===Finished Calculating air quality score periodically at {}===", endTime);
+        log.info("Duration: {}, Total devices processed: {}, Error: {}", duration, processedCount, failedCount);
+    }
+
+    public void calculateScoresForDevice(Long deviceId) {
+        //최신 7개 데이터 조회
+        List<DeviceAirQualityData> airQualityDataList = airQualityDataRepository.findTop7ByDeviceIdOrderByCreatedAtDesc(deviceId);
+
+        if (airQualityDataList.isEmpty()) {
+            log.warn("No data found for device ID: {}", deviceId);
+            throw new CustomException(ErrorCode.DEVICE_AIR_DATA_NOT_FOUND);
+        }
+
+        for (DeviceAirQualityData airQualityData : airQualityDataList) {
+            try{
+                airQualityScoreService.calculateAndSaveDeviceScore(airQualityData);
+                log.debug("Score calculation successful for data ID: {}", airQualityData.getId());
+            }
+            catch (Exception e){
+                log.error("Score calculation error for data ID: {}", airQualityData.getId(), e);
+            }
+        }
+        log.debug("===Finished calculateScoresForDevice for device ID: {}===", deviceId);
+    }
+
+}

--- a/src/test/java/com/example/smartair/service/airQualityService/AirQualityScoreServiceTest.java
+++ b/src/test/java/com/example/smartair/service/airQualityService/AirQualityScoreServiceTest.java
@@ -102,7 +102,7 @@ class AirQualityScoreServiceTest {
             when(placeAirQualityScoreRepository.save(any(PlaceAirQualityScore.class))).thenAnswer(inv -> inv.getArgument(0));
 
             // When
-            airQualityScoreService.calculateAndSaveScores(testData);
+            airQualityScoreService.calculateAndSaveDeviceScore(testData);
 
             // Then
             verify(airQualityCalculator).calculateScore(eq(testData));
@@ -138,7 +138,7 @@ class AirQualityScoreServiceTest {
 
             // When & Then
             CustomException exception = assertThrows(CustomException.class, () -> {
-                airQualityScoreService.calculateAndSaveScores(nullData);
+                airQualityScoreService.calculateAndSaveDeviceScore(nullData);
             });
             assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_INPUT_DATA);
             verifyNoInteractions(airQualityCalculator, deviceAirQualityScoreRepository, roomAirQualityScoreRepository, placeAirQualityScoreRepository);
@@ -158,13 +158,13 @@ class AirQualityScoreServiceTest {
 
             // When & Then for Case 1 (DEVICE_NOT_FOUND)
             CustomException exception1 = assertThrows(CustomException.class, () -> {
-                airQualityScoreService.calculateAndSaveScores(dataWithNullDevice);
+                airQualityScoreService.calculateAndSaveDeviceScore(dataWithNullDevice);
             });
             assertEquals(ErrorCode.DEVICE_NOT_FOUND, exception1.getErrorCode());
 
              // When & Then for Case 2 (ROOM_DEVICE_MAPPING_NOT_FOUND)
             CustomException exception2 = assertThrows(CustomException.class, () -> {
-                airQualityScoreService.calculateAndSaveScores(dataWithNoMapping);
+                airQualityScoreService.calculateAndSaveDeviceScore(dataWithNoMapping);
             });
             assertEquals(ErrorCode.ROOM_DEVICE_MAPPING_NOT_FOUND, exception2.getErrorCode());
 
@@ -190,7 +190,7 @@ class AirQualityScoreServiceTest {
             when(roomAirQualityScoreRepository.findByRoom_Place(null)).thenReturn(Collections.emptyList()); // findByRoom_Place(null) 호출 예상
 
             // When
-            airQualityScoreService.calculateAndSaveScores(dataWithNullPlace);
+            airQualityScoreService.calculateAndSaveDeviceScore(dataWithNullPlace);
 
             // Then
             verify(airQualityCalculator).calculateScore(eq(dataWithNullPlace));


### PR DESCRIPTION
## #️⃣ Issue Number
#32 

## 📝 요약(Summary)
1. AirQualityScoreService를 수정하여 <디바이스 공기질 점수 계산 -> 방 평균 공기질 점수 업데이트 -> 공간 평균 공기질 점수 업데이트> 방식으로 순차적으로 트리거되도록 구현하였습니다.
2. AirQualityScoreCalculationScheduler :  1시간 간격으로 활성 상태의 모든 디바이스의 최신 7개 데이터를 조회하여 각 데이터에 대해 공기질 점수 계산을 수행하도록 구현하였습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
테스트 추가 예정입니다.